### PR TITLE
Add `SampleSuccGauss()` EKP failure handler, fill crashed sim output with NaNs

### DIFF
--- a/src/atmos_interface.jl
+++ b/src/atmos_interface.jl
@@ -48,7 +48,7 @@ function run_forward_model(atmos_config::CA.AtmosConfig)
     integrator = CA.get_integrator(atmos_config)
     sol_res = CA.solve_atmos!(integrator)
     if sol_res.ret_code == :simulation_crashed
-        # TODO: Handle error properly - overwrite data
+        !isnothing(sol_res.sol) && sol_res.sol .= eltype(sol_res.sol)(NaN)
         error(
             "The ClimaAtmos simulation has crashed. See the stack trace for details.",
         )

--- a/src/ekp_interface.jl
+++ b/src/ekp_interface.jl
@@ -56,6 +56,7 @@ function initialize(
         Γ,
         EKP.Inversion();
         rng = rng_ekp,
+        failure_handler_method = EKP.SampleSuccGauss(),
     )
 
     save_parameter_ensemble(


### PR DESCRIPTION
Since we already use `kill-on-invalid-dep` for sbatch scripts, this satisfies the minimal error handling requirement.
Closes #22 